### PR TITLE
Add script to handle symlinks in Windows

### DIFF
--- a/symlinks.ps
+++ b/symlinks.ps
@@ -1,0 +1,12 @@
+# Based on this answer on stack overflow: http://stackoverflow.com/a/5930443/18475
+
+$symlinks = &git ls-files -s | gawk '/120000/{print $4}'
+foreach ($symlink in $symlinks) {
+  write-host $symlink
+  $content = [IO.File]::ReadAllText($symlink)
+  Remove-Item $symlink
+  $adjustedSource = $symlink.replace("/", "\")
+  $adjustedTarget = $content.replace("/", "\")
+  cmd /c mklink "$adjustedSource" "$adjustedTarget"
+  &git update-index --assume-unchanged $symlink
+}

--- a/windows-instructions.txt
+++ b/windows-instructions.txt
@@ -1,0 +1,9 @@
+Since Windows has problems with symlinks, when you checkout symlinks, it will create files with paths.
+On Windows Vista and above, do this to convert to symlinks:
+
+1. Open Powershell and position yourself in the root of the repository (in Github for Windows right-click on the repository and press open in Git Shell
+2. Run these two lines:
+$script = [IO.File]::ReadAllText('.\symlinks.ps')
+invoke-expression $script
+
+NOTE: Be careful not to run this if symlinks are already created or it will create a symlink from the content of the symlink!


### PR DESCRIPTION
Because of problems with Windows, checking out a repository with
symlinks will leave text files with locations to which the symlinks
point instead of actual symlinks. To fix this, the symlinks.ps script is
added along with a windows-instructions.txt file on how to execute the
script.
