### PR TITLE
Fix relative paths for some platforms

### DIFF
--- a/04_bitmap/42_blitting.py
+++ b/04_bitmap/42_blitting.py
@@ -8,8 +8,15 @@ from bitmap import draw_bitmap, mask_from_bitmap
 from utils import get_image_size
 import numpy as np
 
-img = mpimg.imread("../samples/rocks.jpg")
-alien = (mpimg.imread("../samples/Space_invader_dn.png") * 255).astype(np.uint8)
+import os, inspect
+
+current_path = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+
+rocks_path = os.path.abspath(os.path.join(current_path, "../samples/rocks.jpg"))
+alien_path = os.path.abspath(os.path.join(current_path, "../samples/Space_invader_dn.png"))
+
+img = mpimg.imread(rocks_path)
+alien = (mpimg.imread(alien_path) * 255).astype(np.uint8)
 
 plt.ion()
 fig = plt.figure()

--- a/04_bitmap/44_animate.py
+++ b/04_bitmap/44_animate.py
@@ -8,14 +8,23 @@ from bitmap import draw_bitmap_2, mask_from_bitmap
 from utils import get_image_size
 import numpy as np
 
-img = mpimg.imread("../samples/rocks_red.jpg")
+import os, inspect
+
+current_path = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+
+rocks_path = os.path.abspath(os.path.join(current_path, "../samples/rocks_red.jpg"))
+invader_dn_c_path = os.path.abspath(os.path.join(current_path, "../samples/Space_invader_dn_c.png"))
+invader_up_c_path = os.path.abspath(os.path.join(current_path, "../samples/Space_invader_up_c.png"))
+
+
+img = mpimg.imread(rocks_path)
 
 xres, yres = get_image_size(img)
 
-alien = (mpimg.imread("../samples/Space_invader_dn_c.png") * 255) \
+alien = (mpimg.imread(invader_dn_c_path) * 255) \
     .astype(np.uint8)
 mask = mask_from_bitmap(alien)
-alien2 = (mpimg.imread("../samples/Space_invader_up_c.png") * 255) \
+alien2 = (mpimg.imread(invader_up_c_path) * 255) \
     .astype(np.uint8)
 mask2 = mask_from_bitmap(alien2)
 


### PR DESCRIPTION
Sometimes the platform runs on a different path than the .py file
location. With this fix, the paths will always be relative to the file
being executed.
